### PR TITLE
support wildcard selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.4.0
+* Add dataViewWildcard support
+
 ## 2.3.0
 * Packages update
 * Vulnerabilities patched

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 2.4.0
-* Add dataViewWildcard support
+* Add dataViewWildcard for conditional formatting support
 
 ## 2.3.0
 * Packages update

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-utils-dataviewutils",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-utils-dataviewutils",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "dataviewutils",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/src/dataViewWildcard.ts
+++ b/src/dataViewWildcard.ts
@@ -34,8 +34,9 @@ export const enum DataViewWildcardMatchingOption {
 }
 
 export function createDataViewWildcardSelector(dataViewWildcardMatchingOption?: DataViewWildcardMatchingOption) {
-    if (dataViewWildcardMatchingOption == null)
+    if (dataViewWildcardMatchingOption == null) {
         dataViewWildcardMatchingOption = DataViewWildcardMatchingOption.InstancesAndTotals;
+    }
 
     let selector = {
         data: [

--- a/src/dataViewWildcard.ts
+++ b/src/dataViewWildcard.ts
@@ -1,0 +1,50 @@
+/*
+*  Power BI Visualizations
+*
+*  Copyright (c) Microsoft Corporation
+*  All rights reserved.
+*  MIT License
+*
+*  Permission is hereby granted, free of charge, to any person obtaining a copy
+*  of this software and associated documentation files (the ""Software""), to deal
+*  in the Software without restriction, including without limitation the rights
+*  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+*  copies of the Software, and to permit persons to whom the Software is
+*  furnished to do so, subject to the following conditions:
+*
+*  The above copyright notice and this permission notice shall be included in
+*  all copies or substantial portions of the Software.
+*
+*  THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+*  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+*  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+*  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+*  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+*  THE SOFTWARE.
+*/
+
+export const enum DataViewWildcardMatchingOption {
+    /** Match Identities and Totals (default) */
+    InstancesAndTotals = 0,
+    /** Match Instances with Identities only */
+    InstancesOnly = 1,
+    /** Match Totals only */
+    TotalsOnly = 2,
+}
+
+export function createDataViewWildcardSelector(dataViewWildcardMatchingOption?: DataViewWildcardMatchingOption) {
+    if (dataViewWildcardMatchingOption == null)
+        dataViewWildcardMatchingOption = DataViewWildcardMatchingOption.InstancesAndTotals;
+
+    let selector = {
+        data: [
+            {
+                dataViewWildcard:
+                {
+                    matchingOption: dataViewWildcardMatchingOption
+                }
+            }]
+    };
+    return selector;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,9 @@ import * as dataViewObject from "./dataViewObject";
 import * as dataViewObjects from "./dataViewObjects";
 import * as dataViewObjectsParser from "./dataViewObjectsParser";
 import * as dataViewTransform from "./dataViewTransform";
+import * as dataViewWildcard from "./dataViewWildcard";
 import * as validationHelper from "./validationHelper";
 export { converterHelper, dataRoleHelper, dataViewObject,
-    dataViewObjects, dataViewObjectsParser, dataViewTransform,
+    dataViewObjects, dataViewObjectsParser, dataViewTransform, dataViewWildcard,
     validationHelper
 };

--- a/test/dataViewWildcardTest.ts
+++ b/test/dataViewWildcardTest.ts
@@ -1,0 +1,60 @@
+/*
+ *  Power BI Visualizations
+ *
+ *  Copyright (c) Microsoft Corporation
+ *  All rights reserved.
+ *  MIT License
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the ""Software""), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+// powerbi.extensibility.utils.dataview
+import * as DataViewWildcard from "../src/dataViewWildcard";
+
+describe("createDataViewWildcardSelector", () => {
+    it("should return the dataviewWildcard selector with InstancesAndTotals matching option when matching wasn't provided explicitly", () => {
+        let result = DataViewWildcard.createDataViewWildcardSelector();
+        let expected = {
+            data: [
+                {
+                    dataViewWildcard:
+                    {
+                        matchingOption: DataViewWildcard.DataViewWildcardMatchingOption.InstancesAndTotals
+                    }
+                }]
+        };
+
+        expect(result).toEqual(expected);
+    });
+
+    it("should return the dataviewWildcard selector with provided matching option", () => {
+        let result = DataViewWildcard.createDataViewWildcardSelector(DataViewWildcard.DataViewWildcardMatchingOption.InstancesOnly);
+        let expected = {
+            data: [
+                {
+                    dataViewWildcard:
+                    {
+                        matchingOption: DataViewWildcard.DataViewWildcardMatchingOption.InstancesOnly
+                    }
+                }]
+        };
+
+        expect(result).toEqual(expected);
+    });
+});


### PR DESCRIPTION
Create a wrapper for creation of dataviewWildcard selector required for conditionalFormatting support.
Expected usage inside CV code (enumerateObjectInstances) should be:

              import { dataViewWildcard } from "powerbi-visuals-utils-dataviewutils";
              ....
              public enumerateObjectInstances(options: EnumerateVisualObjectInstancesOptions): VisualObjectInstanceEnumeration 
              { 
                 ...             
                selector: 
             dataViewWildcard.createDataViewWildcardSelector(dataViewWildcard.DataViewWildcardMatchingOption.InstancesOnly),
               ....
              }
